### PR TITLE
增加专硕英文；修改文献格式

### DIFF
--- a/HUSTThesis.bst
+++ b/HUSTThesis.bst
@@ -287,9 +287,10 @@ FUNCTION {format.names}
   numnames 'namesleft :=
     { namesleft #0 > }
     { s nameptr
-      % "{f.~}{ll}"
-      % 改动，华中科技大学2023年要求修改为全名格式
-      "{ff~}{ll}" 
+      "{f.~}{ll}"
+      % 改动，华中科技大学2023年要求修改为全名格式   
+      % 20250309fix: 2024 AIA官网下载的模板还是要求名字缩写
+      % "{ff~}{ll}" 
       format.name$
       %bibinfo bibinfo.check
       't :=
@@ -993,8 +994,9 @@ FUNCTION {masterthesis.type}
 FUNCTION {mastersthesis}
 { output.bibitem
   format.authors "author" add.period$ output.check
-  new.block
-  format.title remove.dots ": " * masterthesis.type * output
+  % 20250309 fix：论文类型前面不要冒号
+  % format.title remove.dots ": " * masterthesis.type * output
+  format.title remove.dots "" * masterthesis.type * output
   new.block
   format.address.school output
   %format.madd "address" output.check
@@ -1030,8 +1032,9 @@ FUNCTION {phdthesis.type}
 FUNCTION {phdthesis}
 { output.bibitem
   format.authors "author" add.period$ output.check
-  new.block
-  format.title remove.dots ": " * phdthesis.type * output
+  % 20250309 fix：论文类型前面不要冒号
+  % format.title remove.dots ": " * phdthesis.type * output
+  format.title remove.dots "" * phdthesis.type * output
   new.block
   format.address.school output
   %address output

--- a/body/0cover.tex
+++ b/body/0cover.tex
@@ -27,6 +27,8 @@
 \etitle{\mbox{Randomized Algorithms for Related Problems of} Minimum Cost Perfect Matching With Delay}
 
 \edegree{the Master Degree in Engineering}
+% 专硕用这个
+% \edegree{the Professional Master Degree}
 \esubject{Computing software and theory}
 
 \eauthor{XXX}


### PR DESCRIPTION
1. 英文封面添加专硕英文
2. 根据24年的格式：

包括A院24年9月的模板
http://aia.hust.edu.cn/info/1122/9379.htm

以及计院
24年1月 http://www.cs.hust.edu.cn/info/1086/3725.htm
24年10月http://www.cs.hust.edu.cn/info/1439/4480.htm

都是要求“名用首字母缩写、姓用全称”

3. 中文硕博论文的引用格式
为：李清泉. 基于混合数据结构的三维GIS数据模型与空间分析研究[博士学位论文]. 武汉: 武汉测绘科技大学, 1998
题目后面紧跟论文类型，不需要冒号